### PR TITLE
Add power switch support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,4 +19,5 @@ project(gas_ces)
 
 zephyr_include_directories(include)
 file(GLOB app_sources src/*.c)
+list(APPEND app_sources src/power_switch.c)
 target_sources(app PRIVATE ${app_sources})

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ stateDiagram-v2
 
 Custom board, Out of Tree
 
+### Power Switch
+
+P0.31 is connected to a tact switch acting as the power button. Holding the
+button for roughly one second places the system into system-off mode. Pressing
+the same button again wakes the device.
+
 ## Electrochemical Gas Sensor
 
 - O2

--- a/boards/arm/hhs_nrf52832/hhs_nrf52832.dts
+++ b/boards/arm/hhs_nrf52832/hhs_nrf52832.dts
@@ -38,8 +38,8 @@
 		power-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 	};
 
-	leds {
-		compatible = "gpio-leds";
+        leds {
+                compatible = "gpio-leds";
         status = "okay";
 
 		led0: led_0 {
@@ -49,8 +49,18 @@
 		led1: led_1 {
 			gpios = <&gpio0 27 GPIO_ACTIVE_HIGH>;
 			label = "low battery indicator led Yellow";
-		};
-	};
+                };
+        };
+
+        buttons {
+                compatible = "gpio-keys";
+                status = "okay";
+
+                button0: sw0 {
+                        gpios = <&gpio0 31 GPIO_ACTIVE_HIGH>;
+                        label = "Power Switch";
+                };
+        };
 
 	pwmleds {
 		compatible = "pwm-leds";
@@ -68,13 +78,14 @@
 	};
 
 	/* These aliases are provided for compatibility with samples */
-	aliases {
-		watchdog0 = &wdt0;
-		led0 = &led0;
-		led1 = &led1;
+        aliases {
+                watchdog0 = &wdt0;
+                led0 = &led0;
+                led1 = &led1;
+                sw0 = &button0;
         greenled = &pwm_led0;
         yellowled = &pwm_led1;
-	};
+        };
 };
 
 &pwm0 {

--- a/prj.conf
+++ b/prj.conf
@@ -29,6 +29,7 @@ CONFIG_BME68X_IAQ_SAMPLE_RATE_ULTRA_LOW_POWER=y
 
 # Power Management
 CONFIG_PM_DEVICE=y
+CONFIG_PM=y
 
 # Settings - Used to store real-time device configuration to flash.
 CONFIG_SETTINGS=y

--- a/src/power_switch.c
+++ b/src/power_switch.c
@@ -1,0 +1,68 @@
+/**
+ * @file power_switch.c - system power control via GPIO button
+ *
+ * @brief Implements a simple power switch using P0.31. Holding the
+ * button for around one second puts the system into system off
+ * state and the same button is used to wake it again.
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/pm.h>
+
+#include <hal/nrf_gpio.h>
+#include <hal/nrf_power.h>
+
+LOG_MODULE_REGISTER(POWER_SWITCH, CONFIG_APP_LOG_LEVEL);
+
+static const struct gpio_dt_spec power_button = GPIO_DT_SPEC_GET_OR(DT_ALIAS(sw0), gpios, {0});
+
+static struct gpio_callback button_cb;
+static struct k_work_delayable power_work;
+static bool sleeping;
+
+static void power_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	if (gpio_pin_get_dt(&power_button) > 0) {
+		sleeping = !sleeping;
+		if (sleeping) {
+#ifdef CONFIG_PM
+			nrf_gpio_cfg_sense_set(power_button.pin, NRF_GPIO_PIN_SENSE_HIGH);
+			pm_state_force(0, &(struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
+			nrf_power_system_off();
+#endif
+		}
+	}
+}
+
+static void button_pressed(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cb);
+	ARG_UNUSED(pins);
+
+	k_work_schedule(&power_work, K_SECONDS(1));
+}
+
+static int power_switch_init(void)
+{
+	if (!device_is_ready(power_button.port)) {
+		return -ENODEV;
+	}
+
+	k_work_init_delayable(&power_work, power_work_handler);
+
+	gpio_pin_configure_dt(&power_button, GPIO_INPUT);
+	gpio_pin_interrupt_configure_dt(&power_button, GPIO_INT_EDGE_TO_ACTIVE);
+
+	gpio_init_callback(&button_cb, button_pressed, BIT(power_button.pin));
+	gpio_add_callback(power_button.port, &button_cb);
+
+	return 0;
+}
+
+SYS_INIT(power_switch_init, APPLICATION, 50);


### PR DESCRIPTION
## Summary
- add gpio-keys entry to board DTS for P0.31 power button
- enable system power management in `prj.conf`
- implement power button logic using `k_work_delayable`
- include new source in the build
- document the power switch usage in README

## Testing
- `./format.sh`
- `west build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68649d2da62c8324829e7f2bb490e0e7